### PR TITLE
Re-added "os" import

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask
 from flask.ext.cache import Cache
 import requests


### PR DESCRIPTION
Hey everyone,

I've been following the python example along, and ran into trouble:

```
$ sudo docker run --link redis:redis -p 5000:5000 -ti --rm registry.giantswarm.io/wonderb0lt/currentweather                          

Traceback (most recent call last):
  File "server.py", line 8, in <module>
    "CACHE_REDIS_HOST": os.getenv("REDIS_PORT_6379_TCP_ADDR"),
```

I've re-added the "os" import and everything is working fine:

```
$ sudo docker run --link redis:redis -p 5000:5000 -ti --rm registry.giantswarm.io/wonderb0lt/currentweather  

 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
```
